### PR TITLE
Raspberry Pi Fixes: NOBLE_REPORT_ALL_HCI_EVENTS variable and alt Mac address format

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,10 @@
 import noble from '@abandonware/noble';
+process.env.NOBLE_REPORT_ALL_HCI_EVENTS = '1'; // needed on Linux including Raspberry Pi
 
 const h5075_uuid = "ec88";
 const h5075_uuid_rev = "88ec"
 const govee_bt_mac = "a4-c1-38";
+const govee_bt_mac_alt = "a4:c1:38";
 
 let DEBUG = false;
 
@@ -11,7 +13,7 @@ const validPeripheral = (peripheral: noble.Peripheral) => {
     const { address, advertisement } = peripheral;
 
     if (!advertisement || !advertisement.manufacturerData) { return false; }
-    if (address && !address.toLowerCase().startsWith(govee_bt_mac)) { return false; }
+    if (address && (!address.toLowerCase().startsWith(govee_bt_mac) && !address.toLowerCase().startsWith(govee_bt_mac_alt))) { return false; }
 
     const hex = advertisement.manufacturerData.toString('hex');
     if (!hex.includes(h5075_uuid_rev)) { return false; }


### PR DESCRIPTION
This is the fix needed that I talked about in https://github.com/asednev/homebridge-plugin-govee/issues/1
It will allow the plugin to work on a Raspberry Pi.

Note, I have not run `npm run build` or bumped the version as I assume you will do that after merge, but I can do it directly in the PR too if you want.